### PR TITLE
perf: enforce margin to protect against global resets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "lit": "^3.3.1"
       },
       "devDependencies": {
-        "@aurodesignsystem/auro-cli": "^3.4.0",
+        "@aurodesignsystem/auro-cli": "^3.4.1",
         "@aurodesignsystem/auro-config": "^1.3.1",
         "@aurodesignsystem/auro-hyperlink": "^8.0.0",
         "@aurodesignsystem/auro-icon": "^9.1.1",
@@ -81,9 +81,9 @@
       "license": "MIT"
     },
     "node_modules/@aurodesignsystem/auro-cli": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-cli/-/auro-cli-3.4.0.tgz",
-      "integrity": "sha512-rSwZlt65ERLXXT6OjOFsf3qpj4cvT/l/sOmJMO2Eujvlq4ke2plMZEOLW4WOH726ckXH/L1EJ5O92LekB5Zs7A==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-cli/-/auro-cli-3.4.1.tgz",
+      "integrity": "sha512-W27k2d047jf47YZa3b5+5OvyW47+KxpJ2OHnLa2aWs3MfoyXFOc3rdTxCI8AzVIe+/FrlIHcuwg42FbDZrXMwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lit": "^3.3.1"
   },
   "devDependencies": {
-    "@aurodesignsystem/auro-cli": "^3.4.0",
+    "@aurodesignsystem/auro-cli": "^3.4.1",
     "@aurodesignsystem/auro-config": "^1.3.1",
     "@aurodesignsystem/auro-hyperlink": "^8.0.0",
     "@aurodesignsystem/auro-icon": "^9.1.1",

--- a/src/styles/auro-tail-group.scss
+++ b/src/styles/auro-tail-group.scss
@@ -67,8 +67,11 @@ $group-sizes: map.keys(private.$groups);
 
   :host([layout="horizontal"][size="#{$size}"]) .group.horizontal ::slotted(auro-tail:first-child),
   :host([layout="horizontal"][size="#{$size}"]) .group.horizontal ::slotted([auro-tail]:first-child) {
-    /* Compensate overlap for expanded tail widths (borders on both sides of both tails) */
-    margin-right: calc(var(--ds-auro-tail-group-horiz-overlap-#{$size}) - 2 * var(--ds-auro-tail-group-horiz-border-w-#{$size}));
+    /* Compensate overlap for expanded tail widths (borders on both sides of both tails)
+    
+    Because this is slotted content & appears in the light DOM, use !important to override any external CSS resets
+    */
+    margin-right: calc(var(--ds-auro-tail-group-horiz-overlap-#{$size}) - 2 * var(--ds-auro-tail-group-horiz-border-w-#{$size})) !important;
     /* First tail above second */
     z-index: var(--ds-auro-tail-z-index-group-front);
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

After testing `auro-tail` in `auro-framework-playground`, the CSS reset file in the Next.js project was negatively affecting the `auro-tail-group`.

https://github.com/AlaskaAirlines/auro-framework-playground

Specifically, the `margin` of the slotted `auro-tail` components was being reset by the global CSS:

```
* {
    box-sizing: border-box;
    padding: 0;
    margin: 0;
}
```

This is because the `auro-tail` components inside `auro-tail-group` are `::slotted`, which places them in the light DOM. This makes them susceptible to global CSS and resets:

https://tomherni.dev/blog/the-specificity-of-slotted/

**Before:**

<img width="376" height="101" alt="Screenshot 2025-12-03 at 1 57 35 PM" src="https://github.com/user-attachments/assets/afcd273f-9d7f-44d9-86f1-59e7c5d3bd03" />

**After:**

<img width="356" height="105" alt="Screenshot 2025-12-03 at 1 57 42 PM" src="https://github.com/user-attachments/assets/e2cd6b81-8b31-4d99-894c-5d912ea07d7b" />


## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Prevent global CSS resets from stripping the horizontal margin between the first slotted auro-tail and subsequent tails in auro-tail-group.